### PR TITLE
Fix for UDPOutputter

### DIFF
--- a/lib/log4r/outputter/udpoutputter.rb
+++ b/lib/log4r/outputter/udpoutputter.rb
@@ -17,8 +17,8 @@ module Log4r
      
     def initialize(_name, hash={})
       super(_name, hash)
-      @host = hash[:hostname]
-      @port = hash[:port]
+      @host = (hash[:hostname] or hash["hostname"])
+      @port = (hash[:port] or hash["port"])
 
       begin 
 	Logger.log_internal {


### PR DESCRIPTION
Added hash keys "hostname" and "port" on UDPOutputter instead of just :hostname and :port to support configurator.
