### PR TITLE
Wrapped an argument in parentheses to silence JRuby "Ambiguous First Argument" warnings 

### DIFF
--- a/lib/log4r/formatter/patternformatter.rb
+++ b/lib/log4r/formatter/patternformatter.rb
@@ -123,7 +123,7 @@ module Log4r
 
 	  # MDC matches, need to be able to handle String, Symbol or Number
 	  match6sub = /[\{\}\"]/
-	  mdcmatches = match[6].match /\{(:?)(\d*)(.*)\}/
+	  mdcmatches = match[6].match(/\{(:?)(\d*)(.*)\}/)
 
 	  if ( mdcmatches[1] == "" && mdcmatches[2] == "" )
 	    match6sub = /[\{\}]/ # don't remove surrounding "'s if String


### PR DESCRIPTION
Simple fix to silence the following warning in JRuby:

```
.../gems/log4r-1.1.10/lib/log4r/formatter/patternformatter.rb:126 warning: Ambiguous first argument; make sure.
```

No need to actually merge since it's such a trivial fix. You can add the parentheses yourself if you prefer for 1.1.11. Adding them obviously doesn't affect other Ruby interpreters as it is still valid syntax.

Just letting you know.
