### PR TITLE
Log4r was closing a closed socket

### DIFF
--- a/lib/log4r/outputter/iooutputter.rb
+++ b/lib/log4r/outputter/iooutputter.rb
@@ -26,7 +26,7 @@ module Log4r
 
     # Close the IO and sets level to OFF
     def close
-      @out.close unless @out.nil?
+      @out.close unless @out.nil? || closed?
       @level = OFF
       OutputterFactory.create_methods(self)
       Logger.log_internal {"Outputter '#{@name}' closed IO and set to OFF"}

--- a/tests/testoutputter.rb
+++ b/tests/testoutputter.rb
@@ -19,6 +19,9 @@ class TestOutputter < TestCase
     o.close
     assert(f.closed? == true)
     assert(o.level == OFF)
+    assert_nothing_raised {
+      o.close
+    }
   end
   def test_repository
     assert( Outputter['foo3'].class == IOOutputter )


### PR DESCRIPTION
No calling close on a closed socket (for instances where an application starts up then closes whatever socket was passed to IOOutputter).
