### PR TITLE
Fixed one more source of Encoding::UndefinedConversionError errors.

### DIFF
--- a/lib/log4r/outputter/datefileoutputter.rb
+++ b/lib/log4r/outputter/datefileoutputter.rb
@@ -107,7 +107,7 @@ module Log4r
         }
       end
       makeNewFilename
-      @out = File.new(@filename, (@trunc ? "w" : "a"))
+      @out = File.new(@filename, (@trunc ? "wb" : "ab"))
       Logger.log_internal {
         "DateFileOutputter '#{@name}' now writing to #{@filename}"
       }


### PR DESCRIPTION
This is the same problem and fix as https://github.com/colbygk/log4r/pull/4, only for `DateFileOutputter`.
