### PR TITLE
Add 'sync' option to FileOutputter

### DIFF
--- a/lib/log4r/outputter/fileoutputter.rb
+++ b/lib/log4r/outputter/fileoutputter.rb
@@ -40,7 +40,8 @@ module Log4r
 
       @filename = _filename
       if ( @create == true ) then
-	@out = File.new(@filename, (@trunc ? "wb" : "ab")) 
+	@out = File.new(@filename, (@trunc ? "wb" : "ab"))
+        @out.sync = Log4rTools.decode_bool(hash, :sync, false)
 	Logger.log_internal {
 	  "FileOutputter '#{@name}' writing to #{@filename}"
 	}
@@ -52,5 +53,5 @@ module Log4r
     end
 
   end
-  
+
 end


### PR DESCRIPTION
Unicorn allows to reopen log file when it receives the USR1 signal. This is useful when using logrotate for example.

But to be considered as a log file candidate to be reopened, Unicorn select only synced files. To be able to use this mechanism, this patch add a 'sync' boolean option to the FileOutputter to force the created log file to be synced.
