### PR TITLE
Update to make log4r compatible with fresh ruby 3.2.0dev f8455a4faf w…

### DIFF
--- a/lib/log4r/outputter/rollingfileoutputter.rb
+++ b/lib/log4r/outputter/rollingfileoutputter.rb
@@ -34,7 +34,7 @@ module Log4r
       super( _name, hash.merge({:create => false}) )
       if hash.has_key?(:maxsize) || hash.has_key?('maxsize') 
         _maxsize = (hash[:maxsize] or hash['maxsize']).to_i
-        if _maxsize.class != Fixnum
+        if !_maxsize.is_a? Integer
           raise TypeError, "Argument 'maxsize' must be an Fixnum", caller
         end
         if _maxsize == 0
@@ -44,7 +44,7 @@ module Log4r
       end
       if hash.has_key?(:maxtime) || hash.has_key?('maxtime') 
         _maxtime = (hash[:maxtime] or hash['maxtime']).to_i
-        if _maxtime.class != Fixnum
+        if !_maxsize.is_a? Integer
           raise TypeError, "Argument 'maxtime' must be an Fixnum", caller
         end
         if _maxtime == 0
@@ -54,7 +54,7 @@ module Log4r
       end
       if hash.has_key?(:max_backups) || hash.has_key?('max_backups') 
         _max_backups = (hash[:max_backups] or hash['max_backups']).to_i
-        if _max_backups.class != Fixnum
+        if !_maxsize.is_a? Integer
           raise TypeError, "Argument 'max_backups' must be an Fixnum", caller
         end
         @max_backups = _max_backups
@@ -148,7 +148,7 @@ module Log4r
       # File.ctime can return the erstwhile creation time. File.size? can similarly return
       # old information. So instead of simply doing ctime and size checks after File.new, we 
       # do slightly more complicated checks beforehand:
-      if (mode == 'w' || !File.exists?(@filename))
+      if (mode == 'w' || !File.exist?(@filename))
         @start_time = Time.now()
         @datasize = 0
       else

--- a/lib/log4r/version.rb
+++ b/lib/log4r/version.rb
@@ -1,4 +1,4 @@
 module Log4r
-  Log4rVersion = [1, 1, 11].join '.' # deprecate?
+  Log4rVersion = [1, 1, 12].join '.' # deprecate?
   VERSION = Log4rVersion
 end

--- a/log4r.gemspec
+++ b/log4r.gemspec
@@ -9,6 +9,7 @@ require 'log4r/version'
 
 Gem::Specification.new do |gem|
   # gem is a Gem::Specification... see http://docs.rubygems.org/read/chapter/20 for more options
+  gem.required_ruby_version = '>= 2.5'
   gem.name = "log4r"
   gem.version = Log4r::VERSION
   gem.summary = %Q{Log4r, logging framework for ruby}


### PR DESCRIPTION
…hich has removed support to some deprecated methods.

Changes are mainly in rollingfileoutputter.rb:
> exist? replaces exists?
> Fixnum check replaced with Integer

Gem requirements have been updated to start from ruby 2.5 version for backwards compatibility